### PR TITLE
Make HTTP headers matching case-insensitive

### DIFF
--- a/src/main/java/com/wavefront/opentracing/propagation/JaegerWavefrontPropagator.java
+++ b/src/main/java/com/wavefront/opentracing/propagation/JaegerWavefrontPropagator.java
@@ -62,7 +62,7 @@ public class JaegerWavefrontPropagator implements Propagator<TextMap> {
 
     for (Map.Entry<String, String> entry : carrier) {
       String k = entry.getKey().toLowerCase();
-      if (k.equals(traceIdHeader)) {
+      if (k.equalsIgnoreCase(traceIdHeader)) {
         String[] traceData = contextFromTraceIdHeader(entry.getValue());
         if (traceData == null) {
           continue;


### PR DESCRIPTION
The jaeger traceId is imported from the HTTP headers, therefore any string comparison should be case-insensitive as per RFC2616 / RFC7540