### PR TITLE
update sdk deps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,15 +91,8 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-runtime-sdk-jvm</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
         </dependency>
-        <dependency>
-            <!-- Remove this dependendency after we release wavefront-runtime-sdk-jvm -->
-            <groupId>com.wavefront</groupId>
-            <artifactId>wavefront-sdk-java</artifactId>
-            <version>1.12</version>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Ran mvn dependency:tree 
verified it uses wavefront-sdk-java:1.12
O] +- com.wavefront:wavefront-runtime-sdk-jvm:jar:0.9.8:compile
[INFO] |  \- com.wavefront:wavefront-internal-reporter-java:jar:1.0:compile
[INFO] |     +- com.wavefront:wavefront-sdk-java:jar:1.12:compile