### PR TITLE
promote http.status_code tag to Error metrics

### DIFF
--- a/src/main/java/com/wavefront/opentracing/WavefrontTracer.java
+++ b/src/main/java/com/wavefront/opentracing/WavefrontTracer.java
@@ -46,6 +46,7 @@ import static com.wavefront.sdk.common.Constants.NULL_TAG_VAL;
 import static com.wavefront.sdk.common.Constants.SERVICE_TAG_KEY;
 import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
 import static io.opentracing.tag.Tags.SPAN_KIND;
+import static io.opentracing.tag.Tags.HTTP_STATUS;
 
 /**
  * The Wavefront OpenTracing tracer for sending distributed traces to Wavefront.
@@ -260,16 +261,9 @@ public class WavefrontTracer implements Tracer, Closeable {
       // WavefrontSpanReporter not set, so no tracing spans will be reported as metrics/histograms.
       return;
     }
-    // Need to sanitize metric name as application, service and operation names can have spaces
-    // and other invalid metric name characters
-    Map<String, String> pointTags = new HashMap<String, String>() {{
-      put(OPERATION_NAME_TAG, span.getOperationName());
-      put(COMPONENT_TAG_KEY, span.getComponentTagValue());
-    }};
-
-    // avoid iterating through the span tags if user has not instantiated any red-metric custom tags
+    Map<String, String> pointTags = new HashMap<>();
+    Map<String, Collection<String>> spanTags = span.getTagsAsMap();
     if (redMetricsCustomTagKeys.size() > 0) {
-      Map<String, Collection<String>> spanTags = span.getTagsAsMap();
       for (String customTagKey : redMetricsCustomTagKeys) {
         if (spanTags.containsKey(customTagKey)) {
           // Assuming at least one value exists ...
@@ -279,7 +273,6 @@ public class WavefrontTracer implements Tracer, Closeable {
     }
     // span.kind tag will be promoted by default
     pointTags.putIfAbsent(SPAN_KIND.getKey(), NULL_TAG_VAL);
-
     String application = getSingleValuedTagValueOrDefault(span, APPLICATION_TAG_KEY,
         applicationTags.getApplication());
     String service = getSingleValuedTagValueOrDefault(span, SERVICE_TAG_KEY,
@@ -291,18 +284,31 @@ public class WavefrontTracer implements Tracer, Closeable {
     pointTags.put(SHARD_TAG_KEY, getSingleValuedTagValueOrDefault(span, SHARD_TAG_KEY,
         applicationTags.getShard()));
 
+    // propagate http status if the span has error
+    if (spanTags.containsKey(HTTP_STATUS.getKey()) && span.isError()) {
+      pointTags.put(HTTP_STATUS.getKey(), spanTags.get(HTTP_STATUS.getKey()).iterator().next());
+    }
     // Propagate span.kind and any custom tags to ~component.heartbeat
     if (heartbeaterService != null) {
-      heartbeaterService.reportCustomTags(pointTags);
+      heartbeaterService.reportCustomTags(new HashMap<>(pointTags));
     }
 
+    // Add operation and component tag after sending RED heartbeat.
+    // Need to sanitize metric name as application, service and operation names can have spaces
+    // and other invalid metric name characters
+    pointTags.put(OPERATION_NAME_TAG, span.getOperationName());
+    pointTags.put(COMPONENT_TAG_KEY, span.getComponentTagValue());
+
     String metricNamePrefix = application + "." + service + "." + span.getOperationName();
-    wfDerivedReporter.newCounter(new MetricName(sanitize(metricNamePrefix + INVOCATION_SUFFIX),
-        pointTags)).inc();
     if (span.isError()) {
       wfDerivedReporter.newCounter(new MetricName(sanitize(metricNamePrefix + ERROR_SUFFIX),
           pointTags)).inc();
     }
+
+    // Remove http error status before sending request and duration metrics
+    pointTags.remove(HTTP_STATUS.getKey());
+    wfDerivedReporter.newCounter(new MetricName(sanitize(metricNamePrefix + INVOCATION_SUFFIX),
+        pointTags)).inc();
     long spanDurationMicros = span.getDurationMicroseconds();
     // Convert from micros to millis and add to duration counter
     wfDerivedReporter.newCounter(new MetricName(sanitize(metricNamePrefix + TOTAL_TIME_SUFFIX),

--- a/src/test/java/com/wavefront/opentracing/WavefrontSpanTest.java
+++ b/src/test/java/com/wavefront/opentracing/WavefrontSpanTest.java
@@ -80,6 +80,10 @@ public class WavefrontSpanTest {
     Map<String, String> pointTags = pointTags(operationName, new HashMap<String, String>() {{
       put("span.kind", "none");
     }});
+    Map<String, String> errorTags = pointTags(operationName, new HashMap<String, String>() {{
+      put("span.kind", "none");
+      put("http.status_code", "404");
+    }});
     WavefrontSender wfSender = createMock(WavefrontSender.class);
     wfSender.sendSpan(eq(operationName), anyLong(), anyLong(), eq(DEFAULT_SOURCE),
         anyObject(), anyObject(), eq(Collections.emptyList()), eq(Collections.emptyList()),
@@ -93,7 +97,7 @@ public class WavefrontSpanTest {
 
     wfSender.sendMetric(eq(
         "tracing.derived.myApplication.myService.dummyOp.error.count"),
-        eq(1.0), anyLong(), eq(DEFAULT_SOURCE), eq(pointTags));
+        eq(1.0), anyLong(), eq(DEFAULT_SOURCE), eq(errorTags));
     expectLastCall().atLeastOnce();
 
     // TODO - change WavefrontInternalReporter.newWavefrontHistogram to pass in a clock to
@@ -114,7 +118,7 @@ public class WavefrontSpanTest {
         new WavefrontSpanReporter.Builder().withSource(DEFAULT_SOURCE).build(wfSender),
         buildApplicationTags()).setReportFrequenceMillis(50).build();
     tracer.buildSpan("dummyOp").withTag(Tags.ERROR.getKey(), true).
-        start().finish();
+        withTag("http.status_code", "404").start().finish();
     // Sleep for 60+ seconds
     System.out.println("Sleeping for 1 second zzzzz .....");
     Thread.sleep(1000);


### PR DESCRIPTION
This PR will:
1. Promote `http.status_code` tag to custom heartbeat and Error metrics.
2. Remove `operation` and `component` tags from custom heartbeat.

Notes on different set of tags:
| Category                    | Tags                                                                                                            |
|-----------------------------|-----------------------------------------------------------------------------------------------------------------|
| Custom heartbeat            | application, service, cluster, shard, span kind/other custom tags, http status (if error)                       |
| Error metric                | application, service, cluster, shard, span kind/other custom tags, operation, component, http status (if error) |
| Request and Duration metric | application, service, cluster, shard, span kind/other custom tags, operation, component                         |
| Duration histogram          | application, service, cluster, shard, span kind/other custom tags, operation, component, error boolean          |