### PR TITLE
Fixing NPE in WavefrontSpan

### DIFF
--- a/src/main/java/com/wavefront/opentracing/WavefrontSpan.java
+++ b/src/main/java/com/wavefront/opentracing/WavefrontSpan.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -211,7 +212,7 @@ public class WavefrontSpan implements Span {
     }
     if (fields != null) {
       Map<String, String> finalFields = fields.entrySet().stream().collect(
-          toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+          toMap(Map.Entry::getKey, entry -> Objects.toString(entry.getValue(), "")));
       spanLogs.add(new SpanLog(currentTimeMicros, finalFields));
     }
     return this;

--- a/src/test/java/com/wavefront/opentracing/WavefrontTracerTest.java
+++ b/src/test/java/com/wavefront/opentracing/WavefrontTracerTest.java
@@ -132,6 +132,7 @@ public class WavefrontTracerTest {
     Map<String, String> eventsMap = new HashMap<String, String>() {{
       put("event.name", "foo");
       put("event.kind", "error");
+      put("event.metadata", null);
     }};
     span.log(timeStamp2, eventsMap);
     List<SpanLog> spanLogs = span.getSpanLogs();
@@ -139,8 +140,9 @@ public class WavefrontTracerTest {
     assertEquals(timeStamp1, spanLogs.get(0).getTimestamp());
     assertEquals(logMessage, spanLogs.get(0).getFields().get(Fields.EVENT));
     assertEquals(timeStamp2, spanLogs.get(1).getTimestamp());
-    assertEquals(2, spanLogs.get(1).getFields().size());
+    assertEquals(3, spanLogs.get(1).getFields().size());
     assertEquals("foo", spanLogs.get(1).getFields().get("event.name"));
     assertEquals("error", spanLogs.get(1).getFields().get("event.kind"));
+    assertEquals("", spanLogs.get(1).getFields().get("event.metadata"));
   }
 }


### PR DESCRIPTION
In some rear cases, normally as part of exceptions, the value in the entrySet may be null.
Defaulting it to an empty string

Stacktrace:



> java.lang.NullPointerException: null 	at com.wavefront.opentracing.WavefrontSpan.lambda$updateSpanLogsInternal$0(WavefrontSpan.java:214) 	at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Unknown Source) 	at java.util.stream.ReduceOps$3ReducingSink.accept(Unknown Source) 	at java.util.Collections$2.tryAdvance(Unknown Source) 	at java.util.Collections$2.forEachRemaining(Unknown Source) 	at java.util.stream.AbstractPipeline.copyInto(Unknown Source) 	at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) 	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source) 	at java.util.stream.AbstractPipeline.evaluate(Unknown Source) 	at java.util.stream.ReferencePipeline.collect(Unknown Source) 	at com.wavefront.opentracing.WavefrontSpan.updateSpanLogsInternal(WavefrontSpan.java:213) 	at com.wavefront.opentracing.WavefrontSpan.log(WavefrontSpan.java:197) 	at com.wavefront.opentracing.WavefrontSpan.log(WavefrontSpan.java:39) 	at com.vmware.csp.tracing.aspects.TraceableAspect.tracingAdvice(TraceableAspect.java:52) 	at jdk.internal.reflect.GeneratedMethodAccessor322.invoke(Unknown Source) 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) 	at java.lang.reflect.Method.invoke(Unknown Source) 	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) 	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) 	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) 	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) 	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) 	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) 	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) 	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) 	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)